### PR TITLE
Updating workflow by removing concurrency block

### DIFF
--- a/.github/workflows/build-and-push-noble.yml
+++ b/.github/workflows/build-and-push-noble.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - run: uname -a
 
       - name: Starting step summary

--- a/.github/workflows/build-and-push-noble.yml
+++ b/.github/workflows/build-and-push-noble.yml
@@ -114,7 +114,7 @@ jobs:
         run: docker push ${{ env.DOCKER_REPO }}:latest
 
       - name: Archive build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: awscurl-ubuntu-noble
           path: build/awscurl

--- a/.github/workflows/build-and-push-noble.yml
+++ b/.github/workflows/build-and-push-noble.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - run: uname -a
 
       - name: Starting step summary

--- a/.github/workflows/build-and-push-noble.yml
+++ b/.github/workflows/build-and-push-noble.yml
@@ -27,11 +27,6 @@ on:
 permissions:
   contents: read
 
-# Allow one concurrent deployment
-concurrency:
-  group: "push-docker-hub"
-  cancel-in-progress: true
-
 jobs:
   build-push:
     # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

--- a/.github/workflows/build-and-push-noble.yml
+++ b/.github/workflows/build-and-push-noble.yml
@@ -72,7 +72,7 @@ jobs:
       # https://github.com/lukka/run-cmake/issues/152#issuecomment-2995699875
       # https://github.com/lukka/run-vcpkg/issues/243
       - name: Cache vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/vcpkg_cache
           key: vcpkg-ubuntu-noble-${{ hashFiles('vcpkg.json', 'vcpkg_overlay/**', 'CMakeLists.txt', 'CMakePresets.json') }}


### PR DESCRIPTION
The concurrency was set at the workflow level which was probably wrong from the start and it used a fixed group name. What that meant was that a PR run would cancel a run that was triggered by pushing master.

Since PR builds don't push, it is OK to have them run anytime. And since other builds will push to a tag derived from the current hash it is fine for them to run concurrently.

If you really need to make sure workflows or jobs in workflows are not running concurrently, this is the only tool you have and it is not good because YOUR ONLY OPTION is to cancel the operation that is currently running. There is no way to wait for a workflow/job that is currently running before allowing a following operation proceed.

https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency