### PR TITLE
Adding GitHub workflow to re-tag an image

### DIFF
--- a/.github/workflows/build-and-push-noble.yml
+++ b/.github/workflows/build-and-push-noble.yml
@@ -95,7 +95,7 @@ jobs:
       # Login to Docker Hub
       - name: Login to Docker Hub
         if: steps.set-push.outputs.doPush == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/retag-image.yml
+++ b/.github/workflows/retag-image.yml
@@ -1,0 +1,40 @@
+name: Re-tag an image
+
+on:
+  workflow_dispatch:
+    source_tag:
+      description: 'Source tag (e.g., noble-<hash>)'
+      required: true
+    target_tag:
+      description: 'Target tag (e.g., 1.0.0)'
+      required: true
+
+jobs:
+  retag-image:
+    runs-on: ubuntu-24.04
+
+    env:
+      DOCKER_REPO: ${{ vars.DOCKERHUB_USERNAME }}/awscurl
+      SOURCE_TAG: ${{ github.event.inputs.source_tag }}
+      TARGET_TAG: ${{ github.event.inputs.target_tag }}
+
+    steps:
+      - name: Adding step summary
+        run: |
+          echo "Re-tagging existing image: ${{ env.SOURCE_TAG }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "With target_tag: ${{ env.TARGET_TAG }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Pull existing image from Docker Hub
+        run: docker pull ${{ env.DOCKER_REPO }}:${{ env.SOURCE_TAG }}
+
+      - name: Re-tag the image
+        run: docker tag ${{ env.DOCKER_REPO }}:${{ env.SOURCE_TAG }} ${{ env.DOCKER_REPO }}:${{ env.TARGET_TAG }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push the new tag
+        run: docker push ${{ env.DOCKER_REPO }}:${{ env.TARGET_TAG }}

--- a/.github/workflows/retag-image.yml
+++ b/.github/workflows/retag-image.yml
@@ -31,7 +31,7 @@ jobs:
         run: docker tag ${{ env.DOCKER_REPO }}:${{ env.SOURCE_TAG }} ${{ env.DOCKER_REPO }}:${{ env.TARGET_TAG }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This adds a GitHub workflow that will re-tag an image in Docker Hub, allowing an image to be tagged with a version number after a release tag has been added in the GitHub repo.
