### PR TITLE
Fixing inputs in retag-image workflow

### DIFF
--- a/.github/workflows/retag-image.yml
+++ b/.github/workflows/retag-image.yml
@@ -2,12 +2,13 @@ name: Re-tag an image
 
 on:
   workflow_dispatch:
-    source_tag:
-      description: 'Source tag (e.g., noble-<hash>)'
-      required: true
-    target_tag:
-      description: 'Target tag (e.g., 1.0.0)'
-      required: true
+    inputs:
+      source_tag:
+        description: 'Source tag (e.g., noble-<hash>)'
+        required: true
+      target_tag:
+        description: 'Target tag (e.g., 1.0.0)'
+        required: true
 
 jobs:
   retag-image:


### PR DESCRIPTION
The "inputs:" section was omitted
