### PR TITLE
Updating `retag-image` with security recommendations

### DIFF
--- a/.github/workflows/retag-image.yml
+++ b/.github/workflows/retag-image.yml
@@ -11,6 +11,9 @@ on:
         description: 'Target tag (e.g., 1.0.0)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   retag-image:
     runs-on: ubuntu-24.04
@@ -34,7 +37,7 @@ jobs:
         run: docker tag ${DOCKER_REPO}:${SOURCE_TAG} ${DOCKER_REPO}:${TARGET_TAG}
 
       - name: 🔑 Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.10
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This updates  the `retag-image` workflow:
* Use a pinned version for `docker/login-action`, pinned to a commit hash
* Adding `permissions` block