### PR TITLE
Unpin GitHub maintained actions

### DIFF
--- a/.github/workflows/build-and-push-noble.yml
+++ b/.github/workflows/build-and-push-noble.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
       - name: 📝 Log info about this runner
         run: uname -a
 
@@ -84,7 +84,7 @@ jobs:
       # https://github.com/lukka/run-cmake/issues/152#issuecomment-2995699875
       # https://github.com/lukka/run-vcpkg/issues/243
       - name: 🔧 Setup vcpkg cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/vcpkg_cache
           key: vcpkg-ubuntu-noble-${{ hashFiles('vcpkg.json', 'vcpkg_overlay/**', 'CMakeLists.txt', 'CMakePresets.json') }}
@@ -128,7 +128,7 @@ jobs:
         run: docker push ${IMAGE_NAME_LATEST}
 
       - name: 📤 Archive build artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: awscurl-ubuntu-noble
           path: build/awscurl


### PR DESCRIPTION
CodeQL says these actions are "OK" to be referenced by their version tags.